### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = "0.4.19"
 futures = "0.3.7"
 lazy_static = {version = "1.4.0", optional = true}
 log = "0.4.11"
-prometheus = {version = "^0", optional = true}
+prometheus = {version = "0.13", optional = true}
 pulsar = "4"
 serde = "1.0.117"
 serde_json = "1.0.59"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.